### PR TITLE
fix: add prepublish step so project gets built before npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format:check": "prettier '**/*.{j,t}{s,sx}' --check",
     "lint": "eslint src/**/*",
     "lint:precommit": "eslint src/**/* --fix",
+    "prepublishOnly": "./scripts/prepublish.sh",
     "test": "jest --watch --collectCoverage=false",
     "test:ci": "jest"
   },


### PR DESCRIPTION
- Adds a `prepublishOnly` npm script to build the project before publishing to npm, which should fix the issue where our [latest npm package version is missing the `/dist` folder](https://www.npmjs.com/package/@oaknational/oak-consent-client?activeTab=code).