### PR TITLE
[ENG-805] user id not persisted between reloads

### DIFF
--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -264,6 +264,20 @@ describe("OakConsentClient", () => {
         ]),
       );
     });
+
+    it("should retrieve `userId` from cookies", async () => {
+      getCookieMock.mockReturnValue(
+        JSON.stringify({
+          user: "persistedTestUserId",
+          app: "testApp",
+          policies: [],
+        }),
+      );
+
+      const client = new OakConsentClient(testProps);
+
+      expect(client.userId).toBe("persistedTestUserId");
+    });
   });
 
   describe("Policy versioning", () => {


### PR DESCRIPTION
a subtle bug that only became apparent when I started work on ENG-795 where I needed the `userId` to be persist between reloads.

Ultimately the issue was that the getter for the `userId` was being called before the `consentLog` state had been read from the cookie meaning that the test for `this.consentLogs[0]?.userId` would always be falsey so a new user id would be generated.