### PR TITLE
fix: set proper types on `MockConsentClient`

### DIFF
--- a/src/test/MockConsentClient.ts
+++ b/src/test/MockConsentClient.ts
@@ -1,4 +1,4 @@
-import type { ConsentClient } from "@/types";
+import type { ConsentClient, State } from "@/types";
 
 /**
  * A mock implementation of the ConsentClient interface
@@ -8,20 +8,23 @@ import type { ConsentClient } from "@/types";
 export class MockConsentClient implements ConsentClient {
   appSlug = "testApp";
   userId = "testUserId";
+  constructor(
+    private state: State = {
+      policyConsents: [],
+      requiresInteraction: true,
+    },
+  ) {}
   init() {
     return Promise.resolve();
   }
-  getState() {
-    return {
-      policyConsents: [],
-      requiresInteraction: true,
-    };
+  getState(): State {
+    return this.state;
   }
-  onStateChange = () => {
+  onStateChange: ConsentClient["onStateChange"] = () => {
     return () => {};
   };
-  logConsents = () => {
+  logConsents: ConsentClient["logConsents"] = () => {
     return Promise.resolve();
   };
-  getConsent = () => "pending" as const;
+  getConsent: ConsentClient["getConsent"] = () => "pending";
 }


### PR DESCRIPTION
otherwise they can't be properly typed when spying on them 😮‍💨. I'd thought that would come from the interface but that isn't how it works.

also accepts a state initialisation object to make setting things up easier