### PR TITLE
fix: throw error on bad fetch response

### DIFF
--- a/src/core/OakConsentClientError.ts
+++ b/src/core/OakConsentClientError.ts
@@ -1,0 +1,12 @@
+/**
+ * Custom error class for OakConsentClient.
+ * This will allow us to expose additional information when surfaced through the onError callback.
+ */
+export class OakConsentClientError extends Error {
+  constructor(
+    message: string,
+    public additionalInfo?: unknown,
+  ) {
+    super(message);
+  }
+}

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -5,6 +5,7 @@ import { ConsentState, Policy, State } from "../types";
 import { OakConsentClient } from "./client";
 import { NetworkClient } from "./network";
 import { getCookie, setCookie } from "./cookies";
+import { OakConsentClientError } from "./OakConsentClientError";
 
 jest.mock("./cookies");
 jest.mock("nanoid", () => ({
@@ -344,7 +345,7 @@ describe("OakConsentClient", () => {
     ]);
 
     expect(onError).toHaveBeenCalledWith(
-      new Error("Consents to all policies must be logged."),
+      new OakConsentClientError("Consents to all policies must be logged."),
     );
     expect(networkClient.logConsents).not.toHaveBeenCalled();
   });

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -15,6 +15,7 @@ import {
 
 import { getCookie, setCookie } from "./cookies";
 import { NetworkClient } from "./network";
+import { OakConsentClientError } from "./OakConsentClientError";
 
 const logger = console;
 
@@ -199,7 +200,9 @@ export class OakConsentClient implements ConsentClient {
   ) => {
     try {
       if (consents.length !== this.policies?.length) {
-        throw new Error("Consents to all policies must be logged.");
+        throw new OakConsentClientError(
+          "Consents to all policies must be logged.",
+        );
       }
 
       const payload: ConsentLog[] = [];
@@ -207,7 +210,7 @@ export class OakConsentClient implements ConsentClient {
       consents.forEach((consent) => {
         const policy = this.policies?.find((p) => p.id === consent.policyId);
         if (!policy) {
-          throw new Error("Policy not found");
+          throw new OakConsentClientError("Policy not found");
         }
         payload.push({
           policyId: consent.policyId,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,3 +3,4 @@ export { OakConsentProvider } from "./react/ConsentProvider";
 export { ConsentGate } from "./react/ConsentGate";
 export { useOakConsent } from "./react/useOakConsent";
 export { MockConsentClient as MockOakConsentClient } from "./test/MockConsentClient";
+export { OakConsentClientError } from "./core/OakConsentClientError";

--- a/src/react/useOakConsent.ts
+++ b/src/react/useOakConsent.ts
@@ -2,10 +2,14 @@ import { useContext } from "react";
 
 import { oakConsentContext } from "./ConsentProvider";
 
+import { OakConsentClientError } from "@/core/OakConsentClientError";
+
 function useOakConsent() {
   const context = useContext(oakConsentContext);
   if (!context) {
-    throw new Error("useOakConsent must be used within a OakConsentProvider");
+    throw new OakConsentClientError(
+      "useOakConsent must be used within a OakConsentProvider",
+    );
   }
   return context;
 }


### PR DESCRIPTION
### Description
- adds `OakConsentClientError`
  - replaces all `new Error` so that `onError` is only ever called with the custom error class
  - throw error when we get network requests get bad responses
  - **todo** we might want to check the response body on the log requests (currently f.i. an error would not be thrown if we set a log url to `https://www.example.com`
  - **todo** it would be nice to change the `OnError` type, so that its argument must be a custom error. This requires a few more changes so I'd rather get this in and add that separately